### PR TITLE
Massive rewrite and bug hunt of FindUtil

### DIFF
--- a/code/findutil/README.md
+++ b/code/findutil/README.md
@@ -1,38 +1,40 @@
-# FindUtil - minimal implementation of GNU find in Ruby
+# FindUtil - file search utility
 
 ## Description
 
-FindUtil is a minimal implementation of GNU find tool, written in Ruby.
+FindUtil is a minimalistic implementation of GNU find tool, written in
+Ruby. Its purpose is to find files. It offers case-(in)sensitive, regex
+and/or recursive search.
 
 ## Usage
 
 ```
-Usage: findutil [path] [parameter(s)]...
+Usage: findutil [path] [name/regexp] [parameter(s)]...
 
 Parameters:
-  --version
-      Shows the version of this program
-  --help
-      Show this help text
-  -r, -R, --recursive
-      Search continues within subdirectories as well (default)
-  -nr, --no-recursive
-      Search happens only within current directory, do not recurse
-  -iregex REGEXP
-      Search for a file name using regular expression, case-insensitive
-  -regex REGEXP
-      Search for a file name using regular expression, case-sensitive
-  -iname NAME
-      Search for a file name using shell globs, case-insensitive
-  -name NAME
-      Search for a file name using shell globs, case-sensitive
-  --tux
-      Gives a blessing from our favorite Linux penguin :)
+  --help, -h
+      Show this help message
+
+  --recursive, -r, -R
+      Search continues inside subdirectories as well
+
+  --case, -c
+      Search will be case-sensitive, don't ignore case
+
+  --regexp, -x
+      Search for a file name using a regular expression
+
+Hints:
+If path is missing, it will search in the current working directory.
+If name/regexp is missing, it will search for all file names.
+If no parameters are provided, it will show files in current directory.
+Search is not recursive by default, it doesn't search in subdirectories.
+Searches are not case sensitive by default, so 'A' is same as 'a'. 
 ```
 
 ## Copyright info
 
-Copyright (C) 2016 Filip Dimovski.
+Copyright (C) 2016 Filip Dimovski
 
 This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/code/findutil/bin/findutil
+++ b/code/findutil/bin/findutil
@@ -1,6 +1,6 @@
 #!/usr/bin/env ruby
 
-#  CLI interface for the file search utility
+#  CLI interface for the file finder utility
 #  
 #  Copyright 2016 Filip Dimovski <rexich@riseup.net>
 #  

--- a/code/findutil/lib/finder.rb
+++ b/code/findutil/lib/finder.rb
@@ -3,32 +3,33 @@
 # File search methods using shell globbing, regular expressions
 
 module FindUtility
-  class FindRegexp
+  class Find
     def initialize(path, pattern, case_sensitive, recursive)
       @path, @pattern = path, pattern
-      @flags = ! case_sensitive ?
-        (Regexp::IGNORECASE | File::FNM_DOTMATCH) : File::FNM_DOTMATCH
-      @glob = recursive ? '**/*' : ''
+      @flags =  if case_sensitive
+                  File::FNM_DOTMATCH
+                else
+                  File::FNM_CASEFOLD | File::FNM_DOTMATCH
+                end
+
+      @globs =  if recursive
+                  '**'
+                else
+                  ''
+                end
     end
 
-    def find
-      Dir.glob(File.join(@path, @glob), @flags)
+    def find_regexp
+      #~ puts "Debug regexp:\npath:#{@path},\npattern:#{@pattern},\nflags:#{@flags},\nglobs:#{@globs}"
+      Dir.glob(File.join(@path, @globs, "*"), @flags)
         .grep(Regexp.new(@pattern))
         .sort
         .each { |x| puts x }
     end
-  end
 
-  class FindName
-    def initialize(path, name, case_sensitive, recursive)
-      @path, @name = path, name
-      @flags = ! case_sensitive ?
-        (Regexp::IGNORECASE | File::FNM_DOTMATCH) : File::FNM_DOTMATCH
-      @glob = recursive ? '**' : ''
-    end
-
-    def find
-      Dir.glob(File.join(@path, @glob, @name), @flags)
+    def find_name
+      #~ puts "Debug name:\npath:#{@path},\npattern:#{@pattern},\nflags:#{@flags},\nglobs:#{@globs}"
+      Dir.glob(File.join(@path, @globs, @pattern), @flags)
         .sort
         .each { |x| puts x }
     end

--- a/code/findutil/lib/options.rb
+++ b/code/findutil/lib/options.rb
@@ -26,7 +26,20 @@ module FindUtility
     end
 
     def search_pattern
-      @args[1]
+      pattern = @args.reject { |x| x[0] == '-' }
+      if path_defined?
+        if pattern.last == path
+          regexp_search? ? ".*" : "*"
+        else
+          pattern.last
+        end
+      else
+        if pattern.last == nil
+          regexp_search? ? ".*" : "*"
+        else
+          pattern.last
+        end
+      end
     end
 
     def recursive?
@@ -37,8 +50,37 @@ module FindUtility
       has_options?(["-c", "--case"])
     end
 
-    def regex_search?
-      has_options?(["--regex"])
+    def regexp_search?
+      has_options?(["-x", "--regexp"])
+    end
+
+    def show_usage
+      puts <<-HELP
+File finder utility, version #{FindUtility::Runner::Version}
+Copyright (c) 2016 Filip Dimovski. Licensed under GPLv3+.
+
+Usage: #{@prog_name} [path] [name/regexp] [parameter(s)]...
+
+Parameters:
+  --help, -h
+      Show this help message
+
+  --recursive, -r, -R
+      Search continues inside subdirectories as well
+
+  --case, -c
+      Search will be case-sensitive, don't ignore case
+
+  --regexp, -x
+      Search for a file name using a regular expression
+
+Hints:
+If path is missing, it will search in the current working directory.
+If name/regexp is missing, it will search for all file names.
+If no parameters are provided, it will show files in current directory.
+Search is not recursive by default, it doesn't search in subdirectories.
+Searches are not case sensitive by default, so 'A' is same as 'a'. 
+HELP
     end
 
     private
@@ -46,6 +88,5 @@ module FindUtility
     def has_options?(options)
       options.count { |option| @args.include?(option) } > 0
     end
-
   end
 end

--- a/code/findutil/lib/runner.rb
+++ b/code/findutil/lib/runner.rb
@@ -5,10 +5,8 @@
 require_relative '../lib/finder.rb'
 require_relative '../lib/options.rb'
 
-
 module FindUtility
   class Runner
-
     Version = 0.2
 
     def initialize(args)
@@ -19,71 +17,31 @@ module FindUtility
     def run
       opts = FindUtility::Options.new(@args)
 
-      # If no command line arguments provided,
-      # show all files in current directory and exit
       if opts.no_options?
-        FindUtility::FindName.new(Dir.pwd, "**", false, false).find
+        FindUtility::Find.new(Dir.pwd, "**", false, false).find_name
         return
       end
 
       if opts.show_usage?
-        show_usage
+        opts.show_usage
         return
       end
 
-      if opts.path_defined?
-        path = opts.path
-        pattern = opts.search_pattern
-      else
-        path = Dir.pwd
-        pattern = opts.path
-      end
+      path =  if opts.path_defined?
+                opts.path
+              else
+                Dir.pwd
+              end
 
-      if opts.regex_search?
-        FindUtility::FindRegexp
-          .new(path, pattern, opts.case_sensitive?, opts.recursive?)
-          .find
+      if opts.regexp_search?
+        FindUtility::Find
+          .new(path, opts.search_pattern, opts.case_sensitive?, opts.recursive?)
+          .find_regexp
       else
-        FindUtility::FindName
-          .new(path, pattern, opts.case_sensitive?, opts.recursive?)
-          .find
+        FindUtility::Find
+          .new(path, opts.search_pattern, opts.case_sensitive?, opts.recursive?)
+          .find_name
       end
     end
-
-    def show_usage
-      puts <<-HELP
-File finder utility, version #{Version}
-Copyright (c) 2016 Filip Dimovski. Licensed under GPLv3+.
-
-Usage: #{@prog_name} [path] [name] [parameter(s)]...
-
-Parameters:
-  --help, -h
-      Show this help message
-
-  --recursive, -r, -R
-      Search continues inside subdirectories as well
-
-  --case, -c
-      Search will be case-sensitive, don't ignore case
-
-  --regex
-      Search for a file name using a regular expression
-
-Hints:
-Search is not recursive by default, it doesn't search in subdirectories.
-Searches are not case sensitive by default, so 'A' is same as 'a'. 
-If no parameters are provided, it will show files in current directory.
-HELP
-    end
-
-    def show_not_exist(file)
-      puts "Directory does not exist: #{file}"
-    end
-
-    def show_no_name
-      puts "No name or regular expression provided."
-    end
-
   end
 end


### PR DESCRIPTION
/code/findutil/README.md: revise description, usage
/code/findutil/bin/findutil: correct typo
/code/findutil/lib/finder.rb: rewrite glob and flag definition to be
more clear, define two methods find_regex and find_name instead of two
separate objects, add and comment out debug output, fix globbing in both
regex and name search
/code/findutil/lib/options.rb: rework the entire search_pattern method,
add '-x' flag for regexp search, move show_usage message here from
runner.rb and add '-x' flag and more descriptions
/code/findutil/lib/runner.rb: fix all calls to FileFind::Find methods,
rewrite path acqisition mechanism, remove usage message and put it in
options.rb